### PR TITLE
Added dev chains view

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -35,4 +35,4 @@ jobs:
           prettier --check "src/**/*.(tsx|ts)"
 
       - name: Pretend we have data.json and run tests
-        run: cp public/test-file.json public/data.json && yarn test
+        run: cp public/test-file.json public/data.json public/data_dev.json && yarn test

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,15 +1,16 @@
-import { render } from "@testing-library/react";
-import App from "./App";
-import { BrowserRouter as Router } from "react-router-dom";
+import {render} from "@testing-library/react";
+import App, {ChainsMode} from "./App";
+import {BrowserRouter as Router} from "react-router-dom";
 
 test("renders ok", () => {
   render(
     <Router>
-      <App />
+      <App mode={ChainsMode.prod}/>
     </Router>
   );
 });
 
 test("data file exists", async () => {
   require("../../public/data.json");
+  require("../../public/data_dev.json");
 });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import {useEffect, useState} from "react";
 import { Chains } from "../scheme";
 import { useLocation } from "react-router-dom";
 import { useLocalStorage } from "../hooks/useLocalStorage";
@@ -14,15 +14,24 @@ function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(" ");
 }
 
-export default function App() {
+interface Props {
+  mode: ChainsMode;
+}
+
+export enum ChainsMode {
+  dev,
+  prod,
+}
+
+export default function App({mode}: Props) {
   const [localStorageNetwork, setLocalStorageNetwork] =
     useLocalStorage("chosenNetwork");
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const [allChains, setAllChains] = useState<Chains>({} as Chains);
   let dataFileName = "data.json";
-  if (useLocation().pathname.split("/").indexOf("dev") > 0) {
-    dataFileName = "data_dev.json";
+  if (mode == ChainsMode.dev) {
+    dataFileName = "../data_dev.json";
   }
   useEffect(() => {
     const fetchData = async () => {
@@ -30,7 +39,7 @@ export default function App() {
         .then((response) => response.json())
         .catch((e) => {
           console.error(
-            "Unable to fetch data file. Run `make collector` to generate it"
+            `Unable to fetch data file ${dataFileName}. Run 'make collector' to generate it`
           );
           return e;
         });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,20 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
-import { BrowserRouter as Router } from "react-router-dom";
-import App from "./components/App";
+import {
+  BrowserRouter as Router,
+  Route,
+  Routes,
+} from "react-router-dom";
+import App, {ChainsMode} from "./components/App";
 
 ReactDOM.render(
   <Router>
     <React.StrictMode>
-      <App />
+      <Routes>
+        <Route path="/metadata-portal" element={<App mode={ChainsMode.prod} />}/>
+        <Route path="/metadata-portal/dev" element={<App mode={ChainsMode.dev} />}/>
+      </Routes>
     </React.StrictMode>
   </Router>,
   document.getElementById("root")


### PR DESCRIPTION
### The problem
There are 2 files in the nova-utils repository with chains configuration. 1st of them `chains.json` is used for the production builds, the 2nd one `chains_dev.json` is used for dev builds.
When then configuration for the Metadata portal is built based on the nova-utils there are 2 files generated data.json that matches chains.json and data_dev.json that matches chains_dev.json.
For regular users (production users) there is no need to show chains from data_dev.json. However for application developers there should be an option to show chains from data.json.

### The solution
In order not to overload the UI of the Metadata portal and don't confuse regular (production) users with words like *dev, debug, etc*, I decided to add the url `/dev` that will load the data from data_dev.json file.
The technical solution looks not so good as it may be. It will be nice to advice some improvements.